### PR TITLE
Migrate project from Poetry to uv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /.lake
+.venv/
+__pycache__/
+*.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - MCP tool check_lean that takes Lean 4 source code and checks it with the Lean executable
 - pbtdp.py: command-line script, takes a filename containing Lean source code and a function signature, generate sample inputs and evaluates the function on those inputs.
-  Usage: `poetry run python pbtdp.py <filename> <function signature> [--num_test=N]`
+  Usage: `uv run python pbtdp.py <filename> <function signature> [--num_test=N]`
 
 
 # Development workflow
@@ -38,7 +38,7 @@
 2. **Property-based testing with pbtdp.py**
    - Pass the complete function signature including proof arguments:
      ```
-     poetry run python pbtdp.py <filename> "<function> (arg1: Type1) (arg2: Type2) (proof1: P1) (proof2: P2)" --num_test=N
+     uv run python pbtdp.py <filename> "<function> (arg1: Type1) (arg2: Type2) (proof1: P1) (proof2: P2)" --num_test=N
      ```
    - The script handles generating test cases and proof terms for the arguments
    - Default is 5 test cases, increase with `--num_test=N` for better coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,19 @@
-[tool.poetry]
+[project]
 name = "leantool"
 version = "0.1.0"
 description = ""
-authors = ["Your Name <you@example.com>"]
+authors = [{ name = "Your Name", email = "you@example.com" }]
 readme = "README.md"
-
-[tool.poetry.dependencies]
-python = "^3.11"
-litellm = "^1.71.0"
-streamlit = "^1.40.1"
-jsonlines = "^4.0.0"
-flask = "^3.1.0"
-pantograph = { file = "PyPantograph/dist/pantograph-0.3.7-cp312-cp312-manylinux_2_31_x86_64.whl" }
-mcp = {extras = ["cli"], version = "^1.3.0"}
+requires-python = ">=3.11"
+dependencies = [
+    "litellm>=1.71.0",
+    "streamlit>=1.40.1",
+    "jsonlines>=4.0.0",
+    "flask>=3.1.0",
+    "pantograph @ file:///PyPantograph/dist/pantograph-0.3.7-cp312-cp312-manylinux_2_31_x86_64.whl",
+    "mcp[cli]>=1.3.0",
+]
 
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
- Convert pyproject.toml from Poetry format to PEP 621 (uv-compatible)
- Update build backend from poetry-core to hatchling
- Replace `poetry run` with `uv run` in CLAUDE.md
- Add .venv/, __pycache__/, *.pyc to .gitignore