### PR TITLE
Update PyPantograph to use git dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "streamlit>=1.40.1",
     "jsonlines>=4.0.0",
     "flask>=3.1.0",
-    "pantograph @ file:///PyPantograph/dist/pantograph-0.3.7-cp312-cp312-manylinux_2_31_x86_64.whl",
+    "pantograph @ git+https://github.com/stanford-centaur/PyPantograph",
     "mcp[cli]>=1.3.0",
 ]
 


### PR DESCRIPTION
Replace local wheel file with git+https installation from stanford-centaur/PyPantograph repository.